### PR TITLE
[codex] Harden syllabifier and add text support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,12 @@
 # Makefile for the epa-syllabifier project
 
-.PHONY: help install install-dev test test-verbose test-coverage clean format lint all venv activate
+.PHONY: help venv activate ensure-venv install install-dev test test-verbose test-coverage format lint clean clean-venv build all dev-setup quick-test test-file
 
 # Variables
 VENV_DIR := .venv
 PYTHON := python3
-PIP := pip3
-PYTEST := pytest
-
-# Check if we're in a virtual environment, if not use venv if it exists
-ifdef VIRTUAL_ENV
-    VENV_PYTHON := python
-    VENV_PIP := pip
-else ifneq (,$(wildcard $(VENV_DIR)/bin/python))
-    VENV_PYTHON := $(VENV_DIR)/bin/python
-    VENV_PIP := $(VENV_DIR)/bin/pip
-else
-    VENV_PYTHON := $(PYTHON)
-    VENV_PIP := $(PIP)
-endif
+VENV_PYTHON := $(VENV_DIR)/bin/python
+VENV_PIP := $(VENV_PYTHON) -m pip
 
 # Colors for output
 GREEN := \033[0;32m
@@ -67,68 +55,31 @@ install-dev: ensure-venv ## Install development dependencies
 	@echo "$(GREEN)Installing development dependencies...$(NC)"
 	$(VENV_PIP) install -e ".[dev]"
 	@echo "$(YELLOW)Using virtual environment: $(VENV_DIR)$(NC)"
-	# add module install using editable mode
-	$(VENV_PIP) install -e ".[dev]"
 
 test: install-dev ## Run all tests
 	@echo "$(GREEN)Running tests...$(NC)"
-	@if [ -d "$(VENV_DIR)" ]; then \
-		echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"; \
-		$(VENV_PYTHON) -m pytest tests/; \
-	else \
-		echo "$(YELLOW)No virtual environment found, using system Python$(NC)"; \
-		$(PYTHON) -m pytest tests/; \
-	fi
+	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
+	$(VENV_PYTHON) -m pytest tests/
 
 test-verbose: install-dev ## Run tests with detailed output
 	@echo "$(GREEN)Running tests with detailed output...$(NC)"
-	@if [ -d "$(VENV_DIR)" ]; then \
-		echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"; \
-		$(VENV_PYTHON) -m pytest -v tests/; \
-	else \
-		echo "$(YELLOW)No virtual environment found, using system Python$(NC)"; \
-		$(PYTHON) -m pytest -v tests/; \
-	fi
+	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
+	$(VENV_PYTHON) -m pytest -v tests/
 
 test-coverage: install-dev ## Run tests with code coverage
 	@echo "$(GREEN)Running tests with coverage...$(NC)"
-	@if [ -d "$(VENV_DIR)" ]; then \
-		echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"; \
-		$(VENV_PYTHON) -m pytest --cov=epa_syllabifier --cov-report=html --cov-report=term tests/; \
-	else \
-		echo "$(YELLOW)No virtual environment found, using system Python$(NC)"; \
-		$(PYTHON) -m pytest --cov=epa_syllabifier --cov-report=html --cov-report=term tests/; \
-	fi
+	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
+	$(VENV_PYTHON) -m pytest --cov=epa_syllabifier --cov-report=html --cov-report=term tests/
 
-test-watch: install-dev ## Run tests in watch mode (requires pytest-watch)
-	@echo "$(GREEN)Running tests in watch mode...$(NC)"
-	@if [ -d "$(VENV_DIR)" ]; then \
-		echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"; \
-		$(VENV_PYTHON) -m pytest --watch tests/; \
-	else \
-		echo "$(YELLOW)No virtual environment found, using system Python$(NC)"; \
-		$(PYTHON) -m pytest --watch tests/; \
-	fi
-
-format: ## Format code with black
+format: install-dev ## Format code with black
 	@echo "$(GREEN)Formatting code...$(NC)"
-	@if [ -d "$(VENV_DIR)" ]; then \
-		echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"; \
-		$(VENV_PYTHON) -m black epa_syllabifier/ tests/; \
-	else \
-		echo "$(YELLOW)No virtual environment found, using system Python$(NC)"; \
-		$(PYTHON) -m black epa_syllabifier/ tests/; \
-	fi
+	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
+	$(VENV_PYTHON) -m black epa_syllabifier/ tests/
 
-lint: ## Check code format
+lint: install-dev ## Check code format
 	@echo "$(GREEN)Checking code format...$(NC)"
-	@if [ -d "$(VENV_DIR)" ]; then \
-		echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"; \
-		$(VENV_PYTHON) -m black --check epa_syllabifier/ tests/; \
-	else \
-		echo "$(YELLOW)No virtual environment found, using system Python$(NC)"; \
-		$(PYTHON) -m black --check epa_syllabifier/ tests/; \
-	fi
+	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
+	$(VENV_PYTHON) -m black --check epa_syllabifier/ tests/
 
 clean: ## Clean temporary files
 	@echo "$(GREEN)Cleaning temporary files...$(NC)"
@@ -145,41 +96,27 @@ clean-venv: ## Remove virtual environment
 	@echo "$(GREEN)Removing virtual environment...$(NC)"
 	rm -rf $(VENV_DIR)
 
-build: ## Build the package
+build: install-dev ## Build the package
 	@echo "$(GREEN)Building package...$(NC)"
-	@if [ -d "$(VENV_DIR)" ]; then \
-		echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"; \
-		$(VENV_PYTHON) -m build; \
-	else \
-		echo "$(YELLOW)No virtual environment found, using system Python$(NC)"; \
-		$(PYTHON) -m build; \
-	fi
+	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
+	$(VENV_PYTHON) -m build
 
-all: clean install-dev test ## Run cleanup, installation and tests
+all: clean test ## Run cleanup, installation and tests
 
 # Quick development commands
-dev-setup: venv install-dev ## Quick setup for development (create venv and install dev dependencies)
+dev-setup: install-dev ## Quick setup for development (create venv and install dev dependencies)
 	@echo "$(GREEN)Development setup completed$(NC)"
 	@echo "$(YELLOW)To activate the virtual environment, run:$(NC)"
 	@echo "  $(BLUE)source $(VENV_DIR)/bin/activate$(NC)"
 	@echo "$(YELLOW)Or use:$(NC)"
 	@echo "  $(BLUE)make activate$(NC)"
 
-quick-test: ## Quick test without detailed output
-	@if [ -d "$(VENV_DIR)" ]; then \
-		$(VENV_PYTHON) -m pytest tests/ -q; \
-	else \
-		$(PYTHON) -m pytest tests/ -q; \
-	fi
+quick-test: install-dev ## Quick test without detailed output
+	$(VENV_PYTHON) -m pytest tests/ -q
 
 # Command to run a specific test
 # Usage: make test-file FILE=test_syllabifier.py
 test-file: install-dev ## Run a specific test file (use FILE=filename)
 	@echo "$(GREEN)Running $(FILE)...$(NC)"
-	@if [ -d "$(VENV_DIR)" ]; then \
-		echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"; \
-		$(VENV_PYTHON) -m pytest tests/$(FILE) -v; \
-	else \
-		echo "$(YELLOW)No virtual environment found, using system Python$(NC)"; \
-		$(PYTHON) -m pytest tests/$(FILE) -v; \
-	fi 
+	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
+	$(VENV_PYTHON) -m pytest tests/$(FILE) -v

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for the epa-syllabifier project
 
-.PHONY: help venv activate ensure-venv check-uv install install-dev test test-verbose test-coverage test-properties test-matrix format lint check-whitespace clean clean-venv build ci-local all dev-setup quick-test test-file
+.PHONY: help venv activate ensure-venv check-uv install install-dev test test-verbose test-coverage test-properties test-matrix format lint check-whitespace clean clean-venv build ci-local all dev-setup quick-test test-file try
 
 # Variables
 VENV_DIR := .venv
@@ -145,6 +145,9 @@ dev-setup: install-dev ## Quick setup for development (create venv and install d
 
 quick-test: install-dev ## Quick test without detailed output
 	$(VENV_PYTHON) -m pytest -q -m "not properties" tests/
+
+try: ensure-venv ## Start an interactive manual syllabification session
+	$(VENV_PYTHON) -c "from epa_syllabifier.cli import main; main()"
 
 # Command to run a specific test
 # Usage: make test-file FILE=test_syllabifier.py

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 # Makefile for the epa-syllabifier project
 
-.PHONY: help venv activate ensure-venv install install-dev test test-verbose test-coverage format lint clean clean-venv build all dev-setup quick-test test-file
+.PHONY: help venv activate ensure-venv check-uv install install-dev test test-verbose test-coverage test-properties test-matrix format lint check-whitespace clean clean-venv build ci-local all dev-setup quick-test test-file
 
 # Variables
 VENV_DIR := .venv
 PYTHON := python3
 VENV_PYTHON := $(VENV_DIR)/bin/python
 VENV_PIP := $(VENV_PYTHON) -m pip
+UV := uv
+CI_PYTHON := 3.13
+SUPPORTED_PYTHONS := 3.10 3.11 3.12 3.13
 
 # Colors for output
 GREEN := \033[0;32m
@@ -46,6 +49,12 @@ ensure-venv:
 		make venv; \
 	fi
 
+check-uv:
+	@command -v $(UV) >/dev/null 2>&1 || { \
+		echo "$(YELLOW)uv is required for the local Python test matrix. Install it from https://docs.astral.sh/uv/$(NC)"; \
+		exit 1; \
+	}
+
 install: ensure-venv ## Install basic project dependencies
 	@echo "$(GREEN)Installing basic dependencies...$(NC)"
 	$(VENV_PIP) install -e .
@@ -71,6 +80,18 @@ test-coverage: install-dev ## Run tests with code coverage
 	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
 	$(VENV_PYTHON) -m pytest --cov=epa_syllabifier --cov-report=html --cov-report=term tests/
 
+test-properties: install-dev ## Run exhaustive syllabifier property tests
+	@echo "$(GREEN)Running exhaustive syllabifier property tests...$(NC)"
+	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
+	$(VENV_PYTHON) -m pytest -q -m properties tests/
+
+test-matrix: check-uv ## Run tests across supported Python versions with uv
+	@set -e; \
+	for version in $(SUPPORTED_PYTHONS); do \
+		echo "$(GREEN)Running tests with Python $$version...$(NC)"; \
+		$(UV) run --python $$version --isolated --with pytest --no-project python -m pytest -q tests/; \
+	done
+
 format: install-dev ## Format code with black
 	@echo "$(GREEN)Formatting code...$(NC)"
 	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
@@ -80,6 +101,10 @@ lint: install-dev ## Check code format
 	@echo "$(GREEN)Checking code format...$(NC)"
 	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
 	$(VENV_PYTHON) -m black --check epa_syllabifier/ tests/
+
+check-whitespace: ## Check changed files for whitespace errors
+	git diff --check
+	git diff --cached --check
 
 clean: ## Clean temporary files
 	@echo "$(GREEN)Cleaning temporary files...$(NC)"
@@ -101,7 +126,16 @@ build: install-dev ## Build the package
 	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
 	$(VENV_PYTHON) -m build
 
-all: clean test ## Run cleanup, installation and tests
+ci-local: clean check-uv check-whitespace ## Run the complete local CI suite
+	@echo "$(GREEN)Checking code format with isolated Python $(CI_PYTHON)...$(NC)"
+	$(UV) run --python $(CI_PYTHON) --isolated --with black --no-project black --check epa_syllabifier/ tests/
+	@echo "$(GREEN)Running coverage with isolated Python $(CI_PYTHON)...$(NC)"
+	$(UV) run --python $(CI_PYTHON) --isolated --with pytest --with pytest-cov --no-project python -m pytest --cov=epa_syllabifier --cov-report=term tests/
+	$(MAKE) test-matrix
+	@echo "$(GREEN)Building package with isolated Python $(CI_PYTHON)...$(NC)"
+	$(UV) run --python $(CI_PYTHON) --isolated --with build --no-project python -m build
+
+all: ci-local ## Run the complete local CI suite
 
 # Quick development commands
 dev-setup: install-dev ## Quick setup for development (create venv and install dev dependencies)
@@ -112,7 +146,7 @@ dev-setup: install-dev ## Quick setup for development (create venv and install d
 	@echo "  $(BLUE)make activate$(NC)"
 
 quick-test: install-dev ## Quick test without detailed output
-	$(VENV_PYTHON) -m pytest tests/ -q
+	$(VENV_PYTHON) -m pytest -q -m "not properties" tests/
 
 # Command to run a specific test
 # Usage: make test-file FILE=test_syllabifier.py

--- a/Makefile
+++ b/Makefile
@@ -92,15 +92,13 @@ test-matrix: check-uv ## Run tests across supported Python versions with uv
 		$(UV) run --python $$version --isolated --with pytest --no-project python -m pytest -q tests/; \
 	done
 
-format: install-dev ## Format code with black
-	@echo "$(GREEN)Formatting code...$(NC)"
-	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
-	$(VENV_PYTHON) -m black epa_syllabifier/ tests/
+format: check-uv ## Format code with black
+	@echo "$(GREEN)Formatting code with isolated Python $(CI_PYTHON)...$(NC)"
+	$(UV) run --python $(CI_PYTHON) --isolated --with black --no-project black epa_syllabifier/ tests/
 
-lint: install-dev ## Check code format
-	@echo "$(GREEN)Checking code format...$(NC)"
-	@echo "$(BLUE)Using virtual environment: $(VENV_DIR)$(NC)"
-	$(VENV_PYTHON) -m black --check epa_syllabifier/ tests/
+lint: check-uv ## Check code format
+	@echo "$(GREEN)Checking code format with isolated Python $(CI_PYTHON)...$(NC)"
+	$(UV) run --python $(CI_PYTHON) --isolated --with black --no-project black --check epa_syllabifier/ tests/
 
 check-whitespace: ## Check changed files for whitespace errors
 	git diff --check

--- a/README.md
+++ b/README.md
@@ -5,16 +5,23 @@ Módulo Python para la silabificación de palabras.
 ## Uso
 
 ```python
->>> from epa_syllabifier import syllabify
+>>> from epa_syllabifier import hyphenate, syllabify
 >>> syllabify("arcançía")
 ['ar', 'can', 'çía']
+>>> hyphenate("arcançía")
+'ar-can-çía'
 ```
 
-`syllabify()` procesa una única palabra EPA. La función normaliza las
-mayúsculas y los espacios exteriores. También admite guiones interiores,
-que se eliminan antes de aplicar las reglas de silabificación. Las frases,
-los números, la puntuación y los caracteres ajenos al alfabeto EPA producen
-un error `ValueError`.
+`syllabify()` procesa una única unidad de palabra y devuelve sus sílabas como
+lista. `hyphenate()` ofrece el mismo resultado como texto separado por guiones.
+Las funciones normalizan las mayúsculas y los espacios exteriores. También
+admiten guiones ortográficos interiores, como en `l-l`. `hyphenate()` devuelve
+las fronteras silábicas calculadas como guiones.
+
+La librería no valida si la grafía recibida pertenece al estándar EPA:
+silabifica de forma tolerante préstamos, grafías heredadas y caracteres
+desconocidos. Las frases o entradas con espacios interiores producen un error
+`ValueError`, porque contienen más de una unidad de palabra.
 
 ## Desarrollo
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Módulo Python para la silabificación de palabras.
 ['ar', 'can', 'çía']
 ```
 
+`syllabify()` procesa una única palabra EPA. La función normaliza las
+mayúsculas y los espacios exteriores. También admite guiones interiores,
+que se eliminan antes de aplicar las reglas de silabificación. Las frases,
+los números, la puntuación y los caracteres ajenos al alfabeto EPA producen
+un error `ValueError`.
+
 ## Desarrollo
 
 ### Instalación para desarrollo
@@ -69,8 +75,8 @@ make all
 
 ## Requisitos
 
-- Python >= 3.8
+- Python >= 3.10
 
 ## Licencia
 
-Este proyecto está licenciado bajo la Licencia GPL v3 - ver el archivo [LICENSE](LICENSE) para más detalles. 
+Este proyecto está licenciado bajo la Licencia GPL v3 - ver el archivo [LICENSE](LICENSE) para más detalles.

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Módulo Python para la silabificación de palabras y textos.
 >>> syllabify("arcançía")
 ['ar', 'can', 'çí', 'a']
 >>> hyphenate("¡Andalûh EPA!")
-'¡an-da-lûh e-pa!'
+'¡an·da·lûh e·pa!'
 ```
 
 `syllabify()` procesa una única unidad de palabra y devuelve sus sílabas como
 lista. `hyphenate()` procesa texto completo y devuelve las fronteras silábicas
-calculadas como guiones, conservando la puntuación, los espacios y los saltos
-de línea. Las funciones normalizan las mayúsculas de las palabras analizadas.
-También admiten guiones ortográficos interiores, como en `l-l`.
+calculadas como interpunctos (`·`), conservando la puntuación, los espacios,
+los saltos de línea y los guiones ortográficos interiores, como en `l-l`. Las
+funciones normalizan las mayúsculas de las palabras analizadas.
 
 La librería no valida si la grafía recibida pertenece al estándar EPA:
 silabifica de forma tolerante préstamos, grafías heredadas y caracteres
@@ -33,8 +33,8 @@ make try
 ```
 
 Escribe una palabra EPA y pulsa Intro. El comando devuelve las sílabas
-separadas por guiones y queda esperando la siguiente palabra. Pulsa Intro sin
-escribir texto para salir.
+separadas por interpunctos (`·`) y queda esperando la siguiente palabra. Pulsa
+Intro sin escribir texto para salir.
 
 ## Desarrollo
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ make clean
 make all
 ```
 
+### Revisión lingüística
+
+La [auditoría lingüística inicial](docs/linguistic-review.md) recoge las fuentes
+EPA utilizadas, las reglas ya cubiertas y las decisiones pendientes antes de
+ampliar el algoritmo.
+
 ## Requisitos
 
 - Python >= 3.10

--- a/README.md
+++ b/README.md
@@ -49,7 +49,29 @@ make test-verbose
 
 # Ejecutar tests
 make quick-test
+
+# Ejecutar únicamente el barrido exhaustivo de propiedades
+make test-properties
 ```
+
+`make quick-test` omite el barrido exhaustivo para facilitar iteraciones rápidas.
+El resto de objetivos de test incluye las propiedades permanentes del
+silabificador: toda combinación de hasta cuatro caracteres EPA debe procesarse
+sin excepciones, sin sílabas vacías y sin perder caracteres.
+
+### CI local
+
+Antes de guardar un checkpoint relevante en Git, ejecuta:
+
+```bash
+make ci-local
+```
+
+Este comando limpia artefactos temporales, comprueba espacios sobrantes y
+formato, ejecuta cobertura, prueba la suite con Python 3.10, 3.11, 3.12 y 3.13,
+y construye la distribución. La ejecución utiliza
+[`uv`](https://docs.astral.sh/uv/), que instala entornos aislados cuando son
+necesarios.
 
 ### Comandos útiles de desarrollo
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ desconocidos. `syllabify()` produce un error `ValueError` con frases o entradas
 con espacios interiores; para procesar más de una palabra se utiliza
 `hyphenate()`.
 
+### Prueba manual
+
+Para revisar palabras una a una desde la terminal:
+
+```bash
+make try
+```
+
+Escribe una palabra EPA y pulsa Intro. El comando devuelve las sílabas
+separadas por guiones y queda esperando la siguiente palabra. Pulsa Intro sin
+escribir texto para salir.
+
 ## Desarrollo
 
 ### Instalación para desarrollo

--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # EPA Syllabifier
 
-Módulo Python para la silabificación de palabras.
+Módulo Python para la silabificación de palabras y textos.
 
 ## Uso
 
 ```python
 >>> from epa_syllabifier import hyphenate, syllabify
 >>> syllabify("arcançía")
-['ar', 'can', 'çía']
->>> hyphenate("arcançía")
-'ar-can-çía'
+['ar', 'can', 'çí', 'a']
+>>> hyphenate("¡Andalûh EPA!")
+'¡an-da-lûh e-pa!'
 ```
 
 `syllabify()` procesa una única unidad de palabra y devuelve sus sílabas como
-lista. `hyphenate()` ofrece el mismo resultado como texto separado por guiones.
-Las funciones normalizan las mayúsculas y los espacios exteriores. También
-admiten guiones ortográficos interiores, como en `l-l`. `hyphenate()` devuelve
-las fronteras silábicas calculadas como guiones.
+lista. `hyphenate()` procesa texto completo y devuelve las fronteras silábicas
+calculadas como guiones, conservando la puntuación, los espacios y los saltos
+de línea. Las funciones normalizan las mayúsculas de las palabras analizadas.
+También admiten guiones ortográficos interiores, como en `l-l`.
 
 La librería no valida si la grafía recibida pertenece al estándar EPA:
 silabifica de forma tolerante préstamos, grafías heredadas y caracteres
-desconocidos. Las frases o entradas con espacios interiores producen un error
-`ValueError`, porque contienen más de una unidad de palabra.
+desconocidos. `syllabify()` produce un error `ValueError` con frases o entradas
+con espacios interiores; para procesar más de una palabra se utiliza
+`hyphenate()`.
 
 ## Desarrollo
 

--- a/corpus/epa_syllabified.csv
+++ b/corpus/epa_syllabified.csv
@@ -15,7 +15,7 @@ adibinâh,a-di-bi-nâh
 abetênno,a-be-tên-no
 aba,a-ba
 bahón,ba-hón
-abinitío,a-bi-ni-tío
+abinitío,a-bi-ni-tí-o
 abakuá,a-ba-kuá
 abaho,a-ba-ho
 abadiato,a-ba-dia-to
@@ -26,7 +26,7 @@ abahaéro,a-ba-ha-é-ro
 çurupeto,çu-ru-pe-to
 çuruyo,çu-ru-yo
 çuruhano,çu-ru-ha-no
-çuruhía,çu-ru-hía
+çuruhía,çu-ru-hí-a
 yuraguano,yu-ra-gua-no
 ônnitomançia,ôn-ni-to-man-çia
 çurrûcco,çu-rrûc-co

--- a/docs/linguistic-review.md
+++ b/docs/linguistic-review.md
@@ -2,9 +2,10 @@
 
 ## Alcance
 
-`epa-syllabifier` separa una única unidad de palabra. No transcribe castellano
-a EPA ni valida si la ortografía recibida pertenece a EPA. El análisis debe
-ser tolerante con préstamos, grafías heredadas y caracteres desconocidos.
+`epa-syllabifier` separa sílabas sin transcribir castellano a EPA ni validar si
+la ortografía recibida pertenece a EPA. El análisis debe ser tolerante con
+préstamos, grafías heredadas y caracteres desconocidos. `syllabify()` procesa
+una única unidad de palabra; `hyphenate()` admite texto completo.
 
 ## Fuentes
 
@@ -42,34 +43,34 @@ El algoritmo implementa una primera heurística útil:
 - Normaliza mayúsculas y espacios exteriores.
 - Admite guiones ortográficos interiores, como en `l-l`.
 - Acepta las vocales con acento agudo, circunflejo y grave.
+- Agrupa diptongos y triptongos; mantiene como hiato las secuencias con una
+  vocal cerrada acentuada.
 - Intenta silabificar préstamos y grafías no canónicas sin rechazarlos.
 - Ofrece listas de sílabas con `syllabify()` y texto separado por guiones con
-  `hyphenate()`.
+  `hyphenate()`, preservando puntuación, espacios y saltos de línea.
 
 Los tests exhaustivos garantizan que las combinaciones cortas del alfabeto
 admitido no producen excepciones, no pierden caracteres y no generan sílabas
 vacías. Esto comprueba estabilidad técnica, no corrección lingüística.
 
-## Decisiones pendientes
+## Decisiones adoptadas
 
 ### Secuencias vocálicas
 
-La implementación solo agrupa automáticamente una vocal cerrada seguida de
-una abierta. Antes de ampliar esta regla hay que confirmar los criterios EPA
-para diptongos, triptongos e hiatos.
+Las vocales cerradas átonas pueden formar diptongos con otra vocal y
+triptongos con el patrón cerrada-abierta-cerrada. Una vocal cerrada con acento
+agudo rompe el agrupamiento y forma hiato.
 
-| Entrada | Resultado actual | Resultado esperado |
-| --- | --- | --- |
-| `aire` | `a-i-re` | Pendiente |
-| `causa` | `ca-u-sa` | Pendiente |
-| `peine` | `pe-i-ne` | Pendiente |
-| `ciudá` | `ci-u-dá` | Pendiente |
-| `cuidao` | `cu-i-da-o` | Pendiente |
-| `guau` | `gua-u` | Pendiente |
-| `día` | `día` | Pendiente |
-| `tío` | `tío` | Pendiente |
-
-## Decisiones adoptadas
+| Entrada | Separación adoptada |
+| --- | --- |
+| `aire` | `ai-re` |
+| `causa` | `cau-sa` |
+| `peine` | `pei-ne` |
+| `ciudá` | `ciu-dá` |
+| `cuidao` | `cui-da-o` |
+| `guau` | `guau` |
+| `día` | `dí-a` |
+| `tío` | `tí-o` |
 
 ### Validación ortográfica
 
@@ -84,6 +85,13 @@ ortográfico durante el cálculo para poder repartir la geminación correctament
 `syllabify("ponêl-lo")` devuelve `["po", "nêl", "lo"]` y
 `hyphenate("ponêl-lo")` devuelve `"po-nêl-lo"`, con las fronteras silábicas
 representadas como guiones.
+
+### Texto completo
+
+`syllabify()` conserva su contrato de una sola unidad de palabra y devuelve una
+lista de sílabas. `hyphenate()` recorre texto completo y conserva separadores
+como puntuación, espacios y saltos de línea. Por ejemplo,
+`hyphenate("¡Andalûh EPA!")` devuelve `"¡an-da-lûh e-pa!"`.
 
 ## Ampliación del corpus
 

--- a/docs/linguistic-review.md
+++ b/docs/linguistic-review.md
@@ -2,9 +2,9 @@
 
 ## Alcance
 
-`epa-syllabifier` separa una única palabra ya escrita en Andalûh EPA. No
-transcribe castellano a EPA y no pretende validar por sí solo toda la
-ortografía de entrada.
+`epa-syllabifier` separa una única unidad de palabra. No transcribe castellano
+a EPA ni valida si la ortografía recibida pertenece a EPA. El análisis debe
+ser tolerante con préstamos, grafías heredadas y caracteres desconocidos.
 
 ## Fuentes
 
@@ -39,8 +39,12 @@ El algoritmo implementa una primera heurística útil:
 - Trata `n`, `h`, `r` y `m` en posición de coda.
 - Reparte consonantes geminadas entre la coda de una sílaba y el ataque de la
   siguiente: `âtta` se separa como `ât-ta`.
-- Normaliza mayúsculas, espacios exteriores y guiones interiores.
+- Normaliza mayúsculas y espacios exteriores.
+- Admite guiones ortográficos interiores, como en `l-l`.
 - Acepta las vocales con acento agudo, circunflejo y grave.
+- Intenta silabificar préstamos y grafías no canónicas sin rechazarlos.
+- Ofrece listas de sílabas con `syllabify()` y texto separado por guiones con
+  `hyphenate()`.
 
 Los tests exhaustivos garantizan que las combinaciones cortas del alfabeto
 admitido no producen excepciones, no pierden caracteres y no generan sílabas
@@ -65,27 +69,21 @@ para diptongos, triptongos e hiatos.
 | `día` | `día` | Pendiente |
 | `tío` | `tío` | Pendiente |
 
+## Decisiones adoptadas
+
 ### Validación ortográfica
 
-El silabificador comprueba caracteres, pero no valida todavía todas las
-combinaciones ortográficas. Por ejemplo, agrupa `qu` sin limitar expresamente
-la vocal posterior. Hay que decidir si esta librería debe rechazar grafías no
-canónicas o limitarse a silabificarlas.
-
-### Extensiones y préstamos
-
-La implementación histórica admite `s`, `z` y `k` por compatibilidad. La
-propuesta EPA publicada no las incluye en su inventario estándar. El lemario
-de `andaluh-py` también conserva `w` en algunos préstamos, mientras que el
-silabificador la rechaza. Hay que decidir si la API cubre únicamente EPA
-canónico o también préstamos y grafías heredadas.
+El silabificador no rechaza grafías no canónicas. Por ejemplo, puede procesar
+préstamos con `w` o caracteres desconocidos. Su responsabilidad es intentar
+separar una unidad de palabra, no certificar su pertenencia a EPA.
 
 ### Guiones interiores
 
-EPA emplea `l-l` para representar la doble `l`. La API actual admite guiones
-interiores, los elimina durante el cálculo y devuelve sílabas sin guion:
-`ponêl-lo` se convierte en `po-nêl-lo`. Hay que confirmar si esta salida es la
-deseada o si debe conservarse información ortográfica adicional.
+EPA emplea `l-l` para representar la doble `l`. El análisis elimina ese guion
+ortográfico durante el cálculo para poder repartir la geminación correctamente.
+`syllabify("ponêl-lo")` devuelve `["po", "nêl", "lo"]` y
+`hyphenate("ponêl-lo")` devuelve `"po-nêl-lo"`, con las fronteras silábicas
+representadas como guiones.
 
 ## Ampliación del corpus
 

--- a/docs/linguistic-review.md
+++ b/docs/linguistic-review.md
@@ -1,0 +1,99 @@
+# Auditoría lingüística inicial
+
+## Alcance
+
+`epa-syllabifier` separa una única palabra ya escrita en Andalûh EPA. No
+transcribe castellano a EPA y no pretende validar por sí solo toda la
+ortografía de entrada.
+
+## Fuentes
+
+- [Propuesta EPA de ortografía andaluza de 2019][epa-pdf].
+- [Página de presentación de EPA][epa-page].
+- [`andalugeeks/andaluh-py`][andaluh-py], transcriptor mantenido por la misma
+  organización. Su lemario sirve como fuente de ejemplos, pero no contiene
+  fronteras silábicas.
+
+## Reglas verificadas
+
+La propuesta EPA publicada permite establecer esta base:
+
+| Área | Regla documentada |
+| --- | --- |
+| Grafemas vocálicos | `a`, `e`, `i`, `o`, `u` y sus variantes con circunflejo |
+| Circunflejo | `â`, `ê`, `î`, `ô`, `û` indican apertura o aspiración |
+| Acento agudo | `á`, `é`, `í`, `ó`, `ú` indican vocal tónica |
+| Acento grave | `à`, `è`, `ì`, `ò`, `ù` pueden cumplir función diacrítica |
+| `ç` | Representa la solución integradora para realizaciones seseantes, ceceantes, distinguidoras y heheantes |
+| `h` | Siempre se pronuncia; representa `/h/` o `/x/` según la variante |
+| `x` | Representa realizaciones correspondientes al dígrafo castellano `ch` |
+| Fonema `/k/` | Se escribe `c` ante `a`, `â`, `o`, `ô`, `u`, `û`; se escribe `qu` ante `e`, `ê`, `i`, `î` |
+| Geminación | Una consonante posterior a una vocal abierta o aspirada se duplica |
+| Doble `l` | Se escribe `l-l` para evitar confusión con el dígrafo castellano `ll` |
+
+## Cobertura actual
+
+El algoritmo implementa una primera heurística útil:
+
+- Agrupa `qu`, `rr`, ataques consonánticos y secuencias consonante-vocal.
+- Trata `n`, `h`, `r` y `m` en posición de coda.
+- Reparte consonantes geminadas entre la coda de una sílaba y el ataque de la
+  siguiente: `âtta` se separa como `ât-ta`.
+- Normaliza mayúsculas, espacios exteriores y guiones interiores.
+- Acepta las vocales con acento agudo, circunflejo y grave.
+
+Los tests exhaustivos garantizan que las combinaciones cortas del alfabeto
+admitido no producen excepciones, no pierden caracteres y no generan sílabas
+vacías. Esto comprueba estabilidad técnica, no corrección lingüística.
+
+## Decisiones pendientes
+
+### Secuencias vocálicas
+
+La implementación solo agrupa automáticamente una vocal cerrada seguida de
+una abierta. Antes de ampliar esta regla hay que confirmar los criterios EPA
+para diptongos, triptongos e hiatos.
+
+| Entrada | Resultado actual | Resultado esperado |
+| --- | --- | --- |
+| `aire` | `a-i-re` | Pendiente |
+| `causa` | `ca-u-sa` | Pendiente |
+| `peine` | `pe-i-ne` | Pendiente |
+| `ciudá` | `ci-u-dá` | Pendiente |
+| `cuidao` | `cu-i-da-o` | Pendiente |
+| `guau` | `gua-u` | Pendiente |
+| `día` | `día` | Pendiente |
+| `tío` | `tío` | Pendiente |
+
+### Validación ortográfica
+
+El silabificador comprueba caracteres, pero no valida todavía todas las
+combinaciones ortográficas. Por ejemplo, agrupa `qu` sin limitar expresamente
+la vocal posterior. Hay que decidir si esta librería debe rechazar grafías no
+canónicas o limitarse a silabificarlas.
+
+### Extensiones y préstamos
+
+La implementación histórica admite `s`, `z` y `k` por compatibilidad. La
+propuesta EPA publicada no las incluye en su inventario estándar. El lemario
+de `andaluh-py` también conserva `w` en algunos préstamos, mientras que el
+silabificador la rechaza. Hay que decidir si la API cubre únicamente EPA
+canónico o también préstamos y grafías heredadas.
+
+### Guiones interiores
+
+EPA emplea `l-l` para representar la doble `l`. La API actual admite guiones
+interiores, los elimina durante el cálculo y devuelve sílabas sin guion:
+`ponêl-lo` se convierte en `po-nêl-lo`. Hay que confirmar si esta salida es la
+deseada o si debe conservarse información ortográfica adicional.
+
+## Ampliación del corpus
+
+El corpus actual contiene 58 palabras. El lemario de `andaluh-py` contiene
+más de 86 000 transliteraciones y puede utilizarse para seleccionar candidatos
+representativos. Como no incluye fronteras silábicas, cada incorporación al
+corpus debe revisarse antes de convertirse en un resultado esperado.
+
+[epa-pdf]: https://andaluhepa.files.wordpress.com/2019/10/propuesta-de-ortografc3ada-andaluza-epa-actualizada-2019-docx.pdf
+[epa-page]: https://andaluh.es/epa-2/
+[andaluh-py]: https://github.com/andalugeeks/andaluh-py

--- a/docs/linguistic-review.md
+++ b/docs/linguistic-review.md
@@ -46,8 +46,9 @@ El algoritmo implementa una primera heurística útil:
 - Agrupa diptongos y triptongos; mantiene como hiato las secuencias con una
   vocal cerrada acentuada.
 - Intenta silabificar préstamos y grafías no canónicas sin rechazarlos.
-- Ofrece listas de sílabas con `syllabify()` y texto separado por guiones con
-  `hyphenate()`, preservando puntuación, espacios y saltos de línea.
+- Ofrece listas de sílabas con `syllabify()` y texto separado por interpunctos
+  con `hyphenate()`, preservando puntuación, espacios, saltos de línea y
+  guiones ortográficos.
 
 Los tests exhaustivos garantizan que las combinaciones cortas del alfabeto
 admitido no producen excepciones, no pierden caracteres y no generan sílabas
@@ -63,14 +64,14 @@ agudo rompe el agrupamiento y forma hiato.
 
 | Entrada | Separación adoptada |
 | --- | --- |
-| `aire` | `ai-re` |
-| `causa` | `cau-sa` |
-| `peine` | `pei-ne` |
-| `ciudá` | `ciu-dá` |
-| `cuidao` | `cui-da-o` |
+| `aire` | `ai·re` |
+| `causa` | `cau·sa` |
+| `peine` | `pei·ne` |
+| `ciudá` | `ciu·dá` |
+| `cuidao` | `cui·da·o` |
 | `guau` | `guau` |
-| `día` | `dí-a` |
-| `tío` | `tí-o` |
+| `día` | `dí·a` |
+| `tío` | `tí·o` |
 
 ### Validación ortográfica
 
@@ -83,15 +84,16 @@ separar una unidad de palabra, no certificar su pertenencia a EPA.
 EPA emplea `l-l` para representar la doble `l`. El análisis elimina ese guion
 ortográfico durante el cálculo para poder repartir la geminación correctamente.
 `syllabify("ponêl-lo")` devuelve `["po", "nêl", "lo"]` y
-`hyphenate("ponêl-lo")` devuelve `"po-nêl-lo"`, con las fronteras silábicas
-representadas como guiones.
+`hyphenate("ponêl-lo")` devuelve `"po·nêl-lo"`. `hyphenate()` conserva los
+guiones ortográficos existentes y representa las fronteras silábicas
+calculadas con interpunctos (`·`) para que ambas funciones sean distinguibles.
 
 ### Texto completo
 
 `syllabify()` conserva su contrato de una sola unidad de palabra y devuelve una
 lista de sílabas. `hyphenate()` recorre texto completo y conserva separadores
 como puntuación, espacios y saltos de línea. Por ejemplo,
-`hyphenate("¡Andalûh EPA!")` devuelve `"¡an-da-lûh e-pa!"`.
+`hyphenate("¡Andalûh EPA!")` devuelve `"¡an·da·lûh e·pa!"`.
 
 ## Ampliación del corpus
 

--- a/epa_syllabifier/__init__.py
+++ b/epa_syllabifier/__init__.py
@@ -2,6 +2,6 @@
 EPA Syllabifier - Módulo para silabificación de palabras
 """
 
-from .syllabicator import syllabify
+from .syllabicator import hyphenate, syllabify
 
-__all__ = ["syllabify"]
+__all__ = ["hyphenate", "syllabify"]

--- a/epa_syllabifier/__init__.py
+++ b/epa_syllabifier/__init__.py
@@ -1,6 +1,7 @@
 """
 EPA Syllabifier - Módulo para silabificación de palabras
 """
+
 from .syllabicator import syllabify
 
-all = ["syllabify"]
+__all__ = ["syllabify"]

--- a/epa_syllabifier/cli.py
+++ b/epa_syllabifier/cli.py
@@ -5,14 +5,14 @@ Interactive command-line interface for manual syllabification checks.
 import sys
 from typing import TextIO
 
-from .syllabicator import syllabify
+from .syllabicator import hyphenate, syllabify
 
 PROMPT = "epa> "
 WELCOME = "Escribe una palabra EPA por línea. Pulsa Intro sin texto para salir."
 
 
 def run(source: TextIO, target: TextIO, *, interactive: bool = False) -> None:
-    """Read one word per line and print its syllables separated by hyphens."""
+    """Read one word per line and print its syllables separated by interpuncts."""
     if interactive:
         target.write(f"{WELCOME}\n")
 
@@ -32,11 +32,11 @@ def run(source: TextIO, target: TextIO, *, interactive: bool = False) -> None:
             return
 
         try:
-            result = "-".join(syllabify(word))
+            syllabify(word)
         except ValueError as error:
             target.write(f"Error: {error}\n")
         else:
-            target.write(f"{result}\n")
+            target.write(f"{hyphenate(word)}\n")
 
 
 def main() -> None:

--- a/epa_syllabifier/cli.py
+++ b/epa_syllabifier/cli.py
@@ -1,0 +1,44 @@
+"""
+Interactive command-line interface for manual syllabification checks.
+"""
+
+import sys
+from typing import TextIO
+
+from .syllabicator import syllabify
+
+PROMPT = "epa> "
+WELCOME = "Escribe una palabra EPA por línea. Pulsa Intro sin texto para salir."
+
+
+def run(source: TextIO, target: TextIO, *, interactive: bool = False) -> None:
+    """Read one word per line and print its syllables separated by hyphens."""
+    if interactive:
+        target.write(f"{WELCOME}\n")
+
+    while True:
+        if interactive:
+            target.write(PROMPT)
+            target.flush()
+
+        line = source.readline()
+        if line == "":
+            if interactive:
+                target.write("\n")
+            return
+
+        word = line.strip()
+        if not word:
+            return
+
+        try:
+            result = "-".join(syllabify(word))
+        except ValueError as error:
+            target.write(f"Error: {error}\n")
+        else:
+            target.write(f"{result}\n")
+
+
+def main() -> None:
+    """Run the command-line interface using the standard streams."""
+    run(sys.stdin, sys.stdout, interactive=sys.stdin.isatty())

--- a/epa_syllabifier/syllabicator.py
+++ b/epa_syllabifier/syllabicator.py
@@ -5,14 +5,16 @@ Syllabification algorithm based on the alphabet of the Epa language.
 V_OPEN_BASE: set = {"a", "e", "o"}
 V_OPEN_ACCE: set = {"á", "é", "ó"}
 V_OPEN_CIRC: set = {"â", "ê", "ô"}
+V_OPEN_DIAC: set = {"à", "è", "ò"}
 
-V_OPEN_FULL: set = V_OPEN_BASE | V_OPEN_ACCE | V_OPEN_CIRC
+V_OPEN_FULL: set = V_OPEN_BASE | V_OPEN_ACCE | V_OPEN_CIRC | V_OPEN_DIAC
 
 V_CLOS_BASE: set = {"i", "u"}
 V_CLOS_ACCE: set = {"í", "ú"}
 V_CLOS_CIRC: set = {"î", "û"}
+V_CLOS_DIAC: set = {"ì", "ù"}
 
-V_CLOS_FULL: set = V_CLOS_BASE | V_CLOS_ACCE | V_CLOS_CIRC
+V_CLOS_FULL: set = V_CLOS_BASE | V_CLOS_ACCE | V_CLOS_CIRC | V_CLOS_DIAC
 
 V_FULL: set = V_OPEN_FULL | V_CLOS_FULL
 

--- a/epa_syllabifier/syllabicator.py
+++ b/epa_syllabifier/syllabicator.py
@@ -72,28 +72,36 @@ def rule(w: list[str], lower, upper, range) -> list[str]:
     return unpack_list(l)
 
 
-def syllabify(x: str) -> list[str]:
+def syllabify(word: str) -> list[str]:
     """
-    Given a string in EPA, splits by syllables.
+    Given a word, splits it by syllables.
     Example: syllabify("andalûh") -> ['an', 'da', 'lûh']
     """
 
-    if not isinstance(x, str):
+    if not isinstance(word, str):
         raise TypeError("word must be a string")
 
-    x: str = x.lower().strip()
-    if len(x) == 0:
+    word = word.lower().strip()
+    if len(word) == 0:
         return []
 
-    if "-" in x and any(len(part) == 0 for part in x.split("-")):
-        raise ValueError("hyphens are only allowed inside an EPA word")
+    if any(character.isspace() for character in word):
+        raise ValueError("word must be a single unit without whitespace")
 
-    x: str = x.replace("-", "")
-    invalid_characters: set[str] = set(x) - FULL_SET
-    if invalid_characters:
-        raise ValueError("word must contain only EPA alphabet characters")
+    return _syllabify_unit(word.replace("-", ""))
 
-    x: list[str] = list(x)
+
+def hyphenate(word: str) -> str:
+    """
+    Given a word, returns its syllables separated by hyphens.
+    Example: hyphenate("andalûh") -> "an-da-lûh"
+    """
+
+    return "-".join(syllabify(word))
+
+
+def _syllabify_unit(word: str) -> list[str]:
+    x: list[str] = list(word)
 
     x: list[str] = rule(x, "q", "u", "inclusive")  # qu
     x: list[str] = rule(x, "r", "r", "inclusive")  # rr

--- a/epa_syllabifier/syllabicator.py
+++ b/epa_syllabifier/syllabicator.py
@@ -41,6 +41,7 @@ C_FULL: set = (
 
 FULL_SET: set = V_FULL | C_FULL
 WORD_PATTERN = re.compile(r"[^\W_]+(?:-[^\W_]+)*", flags=re.UNICODE)
+SYLLABLE_SEPARATOR = "·"
 
 
 def unpack_list(l: list[str | list[str]]) -> list[str]:
@@ -97,14 +98,43 @@ def syllabify(word: str) -> list[str]:
 
 def hyphenate(text: str) -> str:
     """
-    Given a text, returns its syllables separated by hyphens.
-    Example: hyphenate("¡Andalûh EPA!") -> "¡an-da-lûh e-pa!"
+    Given a text, returns its syllables separated by interpuncts.
+    Example: hyphenate("¡Andalûh EPA!") -> "¡an·da·lûh e·pa!"
     """
 
     if not isinstance(text, str):
         raise TypeError("text must be a string")
 
-    return WORD_PATTERN.sub(lambda match: "-".join(syllabify(match.group())), text)
+    return WORD_PATTERN.sub(lambda match: _hyphenate_word(match.group()), text)
+
+
+def _hyphenate_word(word: str) -> str:
+    syllable_boundaries: set[int] = set()
+    position: int = 0
+    for syllable in syllabify(word)[:-1]:
+        position += len(syllable)
+        syllable_boundaries.add(position)
+
+    orthographic_boundaries: set[int] = set()
+    position = 0
+    for character in word:
+        if character == "-":
+            orthographic_boundaries.add(position)
+        else:
+            position += 1
+
+    rendered: list[str] = []
+    position = 0
+    for character in word.lower():
+        if character == "-":
+            rendered.append(character)
+            continue
+        if position in syllable_boundaries and position not in orthographic_boundaries:
+            rendered.append(SYLLABLE_SEPARATOR)
+        rendered.append(character)
+        position += 1
+
+    return "".join(rendered)
 
 
 def _is_diphthong(first: str, second: str) -> bool:

--- a/epa_syllabifier/syllabicator.py
+++ b/epa_syllabifier/syllabicator.py
@@ -2,6 +2,8 @@
 Syllabification algorithm based on the alphabet of the Epa language.
 """
 
+import re
+
 V_OPEN_BASE: set = {"a", "e", "o"}
 V_OPEN_ACCE: set = {"á", "é", "ó"}
 V_OPEN_CIRC: set = {"â", "ê", "ô"}
@@ -15,6 +17,7 @@ V_CLOS_CIRC: set = {"î", "û"}
 V_CLOS_DIAC: set = {"ì", "ù"}
 
 V_CLOS_FULL: set = V_CLOS_BASE | V_CLOS_ACCE | V_CLOS_CIRC | V_CLOS_DIAC
+V_CLOS_UNSTRESSED: set = V_CLOS_BASE | V_CLOS_CIRC | V_CLOS_DIAC
 
 V_FULL: set = V_OPEN_FULL | V_CLOS_FULL
 
@@ -37,6 +40,7 @@ C_FULL: set = (
 
 
 FULL_SET: set = V_FULL | C_FULL
+WORD_PATTERN = re.compile(r"[^\W_]+(?:-[^\W_]+)*", flags=re.UNICODE)
 
 
 def unpack_list(l: list[str | list[str]]) -> list[str]:
@@ -91,13 +95,66 @@ def syllabify(word: str) -> list[str]:
     return _syllabify_unit(word.replace("-", ""))
 
 
-def hyphenate(word: str) -> str:
+def hyphenate(text: str) -> str:
     """
-    Given a word, returns its syllables separated by hyphens.
-    Example: hyphenate("andalûh") -> "an-da-lûh"
+    Given a text, returns its syllables separated by hyphens.
+    Example: hyphenate("¡Andalûh EPA!") -> "¡an-da-lûh e-pa!"
     """
 
-    return "-".join(syllabify(word))
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+
+    return WORD_PATTERN.sub(lambda match: "-".join(syllabify(match.group())), text)
+
+
+def _is_diphthong(first: str, second: str) -> bool:
+    if first in V_CLOS_ACCE or second in V_CLOS_ACCE:
+        return False
+
+    return first in V_CLOS_UNSTRESSED or second in V_CLOS_UNSTRESSED
+
+
+def _is_triphthong(first: str, second: str, third: str) -> bool:
+    return (
+        first in V_CLOS_UNSTRESSED
+        and second in V_OPEN_FULL
+        and third in V_CLOS_UNSTRESSED
+    )
+
+
+def _group_vowels(tokens: list[str]) -> list[str]:
+    grouped: list[str] = []
+    i: int = 0
+    while i < len(tokens):
+        if (
+            i + 2 < len(tokens)
+            and tokens[i][-1] in V_FULL
+            and tokens[i + 1][0] in V_FULL
+            and tokens[i + 2][0] in V_FULL
+            and _is_triphthong(
+                tokens[i][-1],
+                tokens[i + 1][0],
+                tokens[i + 2][0],
+            )
+        ):
+            grouped.append("".join(tokens[i : i + 3]))
+            i += 3
+            continue
+
+        if (
+            i + 1 < len(tokens)
+            and tokens[i][-1] in V_FULL
+            and tokens[i + 1][0] in V_FULL
+            and _is_diphthong(tokens[i][-1], tokens[i + 1][0])
+        ):
+            grouped.append("".join(tokens[i : i + 2]))
+            i += 2
+            continue
+
+        grouped.append(tokens[i])
+        i += 1
+
+    return grouped
 
 
 def _syllabify_unit(word: str) -> list[str]:
@@ -107,7 +164,7 @@ def _syllabify_unit(word: str) -> list[str]:
     x: list[str] = rule(x, "r", "r", "inclusive")  # rr
     x: list[str] = rule(x, C_OBST_LIQU, C_LIQU, "inclusive")  # /p, k, b, g, f/ + /r, l/
     x: list[str] = rule(x, C_PLOS_ALVE, C_LIQU_FLAP, "inclusive")  # /d, t/ + /r/
-    x: list[str] = rule(x, V_CLOS_FULL, V_OPEN_FULL, "exclusive")  # /i, u/ + /a, e, o/
+    x: list[str] = _group_vowels(x)
     x: list[str] = rule(x, C_FULL, V_FULL, "exclusive")  # CV
 
     # handles n and h in coda position

--- a/epa_syllabifier/syllabicator.py
+++ b/epa_syllabifier/syllabicator.py
@@ -29,13 +29,15 @@ C_LIQU: set = C_LIQU_LATE | C_LIQU_FLAP
 
 C_CODA: set = {"n", "h"}
 
-C_FULL: set = C_PLOS_ALVE | C_OBST_LIQU | C_LIQU | C_CODA | {"ç", "x", "y", "m", "ñ", "s", "z"}
+C_FULL: set = (
+    C_PLOS_ALVE | C_OBST_LIQU | C_LIQU | C_CODA | {"ç", "x", "y", "m", "ñ", "s", "z"}
+)
 
 
 FULL_SET: set = V_FULL | C_FULL
 
 
-def unpack_list(l: list[str|list[str]]) -> list[str]:
+def unpack_list(l: list[str | list[str]]) -> list[str]:
     """
     From a list[str|list[str]], turns the inner list[str] into a merged str item.
     Example: unpack_list(["a", ["b", "c"]]) -> ["a", "bc"]
@@ -59,8 +61,8 @@ def rule(w: list[str], lower, upper, range) -> list[str]:
     l: list = []
     i: int = 0
     while i < len(w):
-        if w[i][-1] in lower and i + 1 < len(w) and w[i+1][0] in upper:
-            l.append(w[i:i+r])
+        if w[i][-1] in lower and i + 1 < len(w) and w[i + 1][0] in upper:
+            l.append(w[i : i + r])
             i += r
         else:
             l.append(w[i])
@@ -68,33 +70,47 @@ def rule(w: list[str], lower, upper, range) -> list[str]:
     return unpack_list(l)
 
 
-def syllabify(x: str) -> list:
-
+def syllabify(x: str) -> list[str]:
     """
     Given a string in EPA, splits by syllables.
     Example: syllabify("andalûh") -> ['an', 'da', 'lûh']
     """
 
-    x: str = " " if len(x) == 0 else x
+    if not isinstance(x, str):
+        raise TypeError("word must be a string")
 
-    x: str = x.lower()
-    x: str = x.strip()
+    x: str = x.lower().strip()
+    if len(x) == 0:
+        return []
+
+    if "-" in x and any(len(part) == 0 for part in x.split("-")):
+        raise ValueError("hyphens are only allowed inside an EPA word")
+
     x: str = x.replace("-", "")
+    invalid_characters: set[str] = set(x) - FULL_SET
+    if invalid_characters:
+        raise ValueError("word must contain only EPA alphabet characters")
+
     x: list[str] = list(x)
 
-    x: list[str] = rule(x, "q", "u", "inclusive")                  # qu
-    x: list[str] = rule(x, "r", "r", "inclusive")                  # rr
-    x: list[str] = rule(x, C_OBST_LIQU, C_LIQU, "inclusive")       # /p, k, b, g, f/ + /r, l/
+    x: list[str] = rule(x, "q", "u", "inclusive")  # qu
+    x: list[str] = rule(x, "r", "r", "inclusive")  # rr
+    x: list[str] = rule(x, C_OBST_LIQU, C_LIQU, "inclusive")  # /p, k, b, g, f/ + /r, l/
     x: list[str] = rule(x, C_PLOS_ALVE, C_LIQU_FLAP, "inclusive")  # /d, t/ + /r/
     x: list[str] = rule(x, V_CLOS_FULL, V_OPEN_FULL, "exclusive")  # /i, u/ + /a, e, o/
-    x: list[str] = rule(x, C_FULL, V_FULL, "exclusive")            # CV
+    x: list[str] = rule(x, C_FULL, V_FULL, "exclusive")  # CV
 
     # handles n and h in coda position
     l: list = []
     i: int = 0
     while i < len(x):
-        if x[i][-1] in V_FULL and i + 2 < len(x) and x[i+1] in C_CODA and x[i+2][0] not in V_FULL:
-            l.append(x[i:i+2])
+        if (
+            x[i][-1] in V_FULL
+            and i + 2 < len(x)
+            and x[i + 1] in C_CODA
+            and x[i + 2][0] not in V_FULL
+        ):
+            l.append(x[i : i + 2])
             i += 2
         else:
             l.append(x[i])
@@ -107,24 +123,25 @@ def syllabify(x: str) -> list:
         l.pop()
 
     # handles coda r and m
-    for i in range(len(l)):
-        if len(l[i]) == 1 and i + 1 < len(l) and i != 0:
-            if l[i] in "r" or l[i] in "m":
-                if l[i+1][0] in C_FULL and l[i-1][-1] in V_FULL:
-                    l[i-1] = l[i-1] + l[i]
-                    l[i] = ""
-    l: list[str] = [i for i in l if i != ""]
+    i: int = 1
+    while i + 1 < len(l):
+        if len(l[i]) == 1 and l[i] in {"r", "m"}:
+            if l[i + 1][0] in C_FULL and l[i - 1][-1] in V_FULL:
+                l[i - 1] = l[i - 1] + l.pop(i)
+                continue
+        i += 1
 
-    # handles germination for coda syllable
-    for i in range(len(l)):
-        if len(l[i]) == 1 and i + 1 < len(l) and i != 0:
-            if l[i] == l[i+1][0]:
-                l[i-1] = l[i-1] + l[i]
-                l[i] = ""
-            elif l[i] == l[i-1][-1]:
-                l[i+1] = l[i] + l[i+1]
-                l[i] = ""
-    l: list[str] = [i for i in l if i != ""]
-
+    # handles gemination for coda syllable
+    i: int = 1
+    while i + 1 < len(l):
+        if len(l[i]) == 1:
+            if l[i] == l[i + 1][0]:
+                l[i - 1] = l[i - 1] + l.pop(i)
+                continue
+            if l[i] == l[i - 1][-1]:
+                l[i + 1] = l[i] + l[i + 1]
+                l.pop(i)
+                continue
+        i += 1
 
     return l

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "epa_syllabifier"
 version = "0.3.0"
-description = "Automatic syllabification module for Spanish words"
+description = "Automatic syllabification module for EPA words and texts"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ classifiers = [
 ]
 dependencies = []
 
+[project.scripts]
+epa-syllabifier = "epa_syllabifier.cli:main"
+
 [project.urls]
 "Homepage" = "https://github.com/andalugeeks/epa-syllabifier"
 "Bug Tracker" = "https://github.com/andalugeeks/epa-syllabifier/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+markers = [
+    "properties: exhaustive invariants over EPA alphabet combinations",
+]
 
 [tool.black]
 target-version = ["py310"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "epa_syllabifier"
 version = "0.3.0"
 description = "Automatic syllabification module for Spanish words"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = "MIT"
 authors = [
     { name = "Andalugeeks Team" }
@@ -20,8 +20,6 @@ classifiers = [
     "Topic :: Text Processing :: Linguistic",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -39,6 +37,7 @@ dependencies = []
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
+    "build",
     "ipdb",
     "black",
     "commitizen>=3.0.0",
@@ -48,10 +47,13 @@ dev = [
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 
+[tool.black]
+target-version = ["py310"]
+
 [tool.commitizen]
 name = "cz_conventional_commits"
 tag_format = "v$version"
 version_scheme = "pep440"
 version_provider = "pep621"
 update_changelog_on_bump = true
-major_version_zero = true 
+major_version_zero = true

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ def test_run_syllabifies_each_input_line():
 
     run(source, target)
 
-    assert target.getvalue() == "an-da-lûh\nguau\n"
+    assert target.getvalue() == "an·da·lûh\nguau\n"
 
 
 def test_run_reports_multiple_words_and_continues():
@@ -24,7 +24,7 @@ def test_run_reports_multiple_words_and_continues():
     run(source, target)
 
     assert target.getvalue() == (
-        "Error: word must be a single unit without whitespace\n" "dí-a\n"
+        "Error: word must be a single unit without whitespace\n" "dí·a\n"
     )
 
 
@@ -34,7 +34,7 @@ def test_run_interactive_session_exits_cleanly_on_eof():
 
     run(source, target, interactive=True)
 
-    assert target.getvalue() == f"{WELCOME}\n{PROMPT}tí-o\n{PROMPT}\n"
+    assert target.getvalue() == f"{WELCOME}\n{PROMPT}tí·o\n{PROMPT}\n"
 
 
 def test_main_uses_standard_streams(monkeypatch):
@@ -45,4 +45,4 @@ def test_main_uses_standard_streams(monkeypatch):
 
     main()
 
-    assert target.getvalue() == "cau-sa\n"
+    assert target.getvalue() == "cau·sa\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,48 @@
+"""
+Tests for the interactive command-line interface.
+"""
+
+import sys
+from io import StringIO
+
+from epa_syllabifier.cli import PROMPT, WELCOME, main, run
+
+
+def test_run_syllabifies_each_input_line():
+    source = StringIO("andalûh\nguau\n\n")
+    target = StringIO()
+
+    run(source, target)
+
+    assert target.getvalue() == "an-da-lûh\nguau\n"
+
+
+def test_run_reports_multiple_words_and_continues():
+    source = StringIO("hola mundo\ndía\n\n")
+    target = StringIO()
+
+    run(source, target)
+
+    assert target.getvalue() == (
+        "Error: word must be a single unit without whitespace\n" "dí-a\n"
+    )
+
+
+def test_run_interactive_session_exits_cleanly_on_eof():
+    source = StringIO("tío\n")
+    target = StringIO()
+
+    run(source, target, interactive=True)
+
+    assert target.getvalue() == f"{WELCOME}\n{PROMPT}tí-o\n{PROMPT}\n"
+
+
+def test_main_uses_standard_streams(monkeypatch):
+    source = StringIO("causa\n\n")
+    target = StringIO()
+    monkeypatch.setattr(sys, "stdin", source)
+    monkeypatch.setattr(sys, "stdout", target)
+
+    main()
+
+    assert target.getvalue() == "cau-sa\n"

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,33 @@
+"""
+Property tests for the syllabifier invariants.
+"""
+
+from itertools import product
+
+import pytest
+
+from epa_syllabifier import syllabify
+from epa_syllabifier.syllabicator import FULL_SET
+
+MAX_EXHAUSTIVE_WORD_LENGTH = 4
+
+
+@pytest.mark.properties
+def test_valid_alphabet_combinations_round_trip_without_empty_syllables():
+    """Check short EPA character combinations exhaustively."""
+    alphabet = sorted(FULL_SET)
+
+    for length in range(1, MAX_EXHAUSTIVE_WORD_LENGTH + 1):
+        for letters in product(alphabet, repeat=length):
+            word = "".join(letters)
+            syllables = syllabify(word)
+
+            assert "".join(syllables) == word
+            assert all(syllables)
+
+
+@pytest.mark.properties
+def test_alphabet_characters_are_case_insensitive():
+    """Check that every EPA alphabet character accepts uppercase input."""
+    for character in FULL_SET:
+        assert "".join(syllabify(character.upper())) == character

--- a/tests/test_syllabifier.py
+++ b/tests/test_syllabifier.py
@@ -5,46 +5,53 @@ Tests for the syllabify function using the corpus epa_syllabified.csv
 import unittest
 import csv
 import os
+import epa_syllabifier
 from epa_syllabifier import syllabify
 
 
 class TestSyllabifier(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         """Load the corpus once for all tests"""
         cls.corpus_data = []
         corpus_path = os.path.join(
-            os.path.dirname(os.path.dirname(__file__)), 'corpus', 'epa_syllabified.csv'
+            os.path.dirname(os.path.dirname(__file__)), "corpus", "epa_syllabified.csv"
         )
-        
-        with open(corpus_path, 'r', encoding='utf-8') as file:
+
+        with open(corpus_path, "r", encoding="utf-8") as file:
             reader = csv.DictReader(file)
             for row in reader:
-                word = row['word']
-                expected_syllables = row['syllabified'].split('-')
+                word = row["word"]
+                expected_syllables = row["syllabified"].split("-")
                 cls.corpus_data.append((word, expected_syllables))
-    
+
     def test_corpus_cases(self):
         """Test each case of the corpus"""
         failed_cases = []
-        
+
         for word, expected_syllables in self.corpus_data:
             with self.subTest(word=word):
                 try:
                     result = syllabify(word)
-                    self.assertEqual(result, expected_syllables, 
-                                   f"Para la palabra '{word}': esperado {expected_syllables}, obtenido {result}")
+                    self.assertEqual(
+                        result,
+                        expected_syllables,
+                        f"Para la palabra '{word}': esperado {expected_syllables}, obtenido {result}",
+                    )
                 except AssertionError as e:
                     failed_cases.append(f"Palabra: {word} - {str(e)}")
-        
+
         if failed_cases:
-            self.fail(f"Fallaron {len(failed_cases)} casos:\n" + "\n".join(failed_cases))
-    
+            self.fail(
+                f"Fallaron {len(failed_cases)} casos:\n" + "\n".join(failed_cases)
+            )
+
     def test_empty_word(self):
         """Test empty word"""
         self.assertEqual(syllabify(""), [])
-    
+        self.assertEqual(syllabify("  "), [])
+
     def test_single_vowel(self):
         """Test single vowel"""
         self.assertEqual(syllabify("a"), ["a"])
@@ -53,28 +60,74 @@ class TestSyllabifier(unittest.TestCase):
         self.assertEqual(syllabify("o"), ["o"])
         self.assertEqual(syllabify("u"), ["u"])
 
+    def test_normalizes_word(self):
+        """Test supported word normalization"""
+        self.assertEqual(syllabify(" TOQUE "), ["to", "que"])
+        self.assertEqual(syllabify("ûl-lero"), ["ûl", "le", "ro"])
+
+    def test_rejects_non_string_input(self):
+        """Test input type validation"""
+        with self.assertRaisesRegex(TypeError, "word must be a string"):
+            syllabify(None)
+
+    def test_rejects_invalid_words(self):
+        """Test that only one EPA word is accepted"""
+        invalid_words = [
+            "hola mundo",
+            "123",
+            "hola!",
+            "-andalûh",
+            "andalûh-",
+            "anda--lûh",
+        ]
+
+        for word in invalid_words:
+            with self.subTest(word=word):
+                with self.assertRaises(ValueError):
+                    syllabify(word)
+
+    def test_gemination_regressions(self):
+        """Test that gemination processing never leaves empty fragments"""
+        for word in ["aaab", "abbc", "aççbo"]:
+            with self.subTest(word=word):
+                syllables = syllabify(word)
+                self.assertEqual("".join(syllables), word)
+                self.assertTrue(all(syllables))
+
+    def test_public_api(self):
+        """Test the package public API"""
+        self.assertEqual(epa_syllabifier.__all__, ["syllabify"])
+
 
 def generate_individual_tests():
     """Generate individual tests for each case of the corpus (for better debugging)"""
-    corpus_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'corpus', 'epa_syllabified.csv')
-    
-    with open(corpus_path, 'r', encoding='utf-8') as file:
+    corpus_path = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "corpus", "epa_syllabified.csv"
+    )
+
+    with open(corpus_path, "r", encoding="utf-8") as file:
         reader = csv.DictReader(file)
         for i, row in enumerate(reader):
-            word = row['word']
-            expected_syllables = row['syllabified'].split('-')
-            
+            word = row["word"]
+            expected_syllables = row["syllabified"].split("-")
+
             def make_test(word, expected):
                 def test_method(self):
                     result = syllabify(word)
-                    self.assertEqual(result, expected, 
-                                   f"Para '{word}': esperado {expected}, obtenido {result}")
+                    self.assertEqual(
+                        result,
+                        expected,
+                        f"Para '{word}': esperado {expected}, obtenido {result}",
+                    )
+
                 return test_method
-            
+
             test_name = f'test_corpus_{i:02d}_{word.replace("-", "_")}'
             test_method = make_test(word, expected_syllables)
             test_method.__name__ = test_name
-            test_method.__doc__ = f'Test para la palabra "{word}" -> {expected_syllables}'
+            test_method.__doc__ = (
+                f'Test para la palabra "{word}" -> {expected_syllables}'
+            )
             setattr(TestSyllabifier, test_name, test_method)
 
 

--- a/tests/test_syllabifier.py
+++ b/tests/test_syllabifier.py
@@ -73,13 +73,18 @@ class TestSyllabifier(unittest.TestCase):
 
     def test_hyphenates_word(self):
         """Test textual output with syllable separators"""
-        self.assertEqual(hyphenate("andalûh"), "an-da-lûh")
-        self.assertEqual(hyphenate("ponêl-lo"), "po-nêl-lo")
+        self.assertEqual(hyphenate("andalûh"), "an·da·lûh")
+        self.assertEqual(hyphenate("ponêl-lo"), "po·nêl-lo")
 
     def test_hyphenates_text_preserving_separators(self):
         """Test full text output while preserving punctuation and whitespace"""
-        self.assertEqual(hyphenate("¡Andalûh EPA!"), "¡an-da-lûh e-pa!")
-        self.assertEqual(hyphenate("Hola, mundo.\nEPA"), "ho-la, mun-do.\ne-pa")
+        self.assertEqual(hyphenate("¡Andalûh EPA!"), "¡an·da·lûh e·pa!")
+        self.assertEqual(hyphenate("Hola, mundo.\nEPA"), "ho·la, mun·do.\ne·pa")
+
+    def test_hyphenates_text_preserving_orthographic_hyphens(self):
+        """Test that EPA orthographic hyphens remain distinguishable"""
+        self.assertEqual(hyphenate("âl-lequín, câl-lô"), "âl-le·quín, câl-lô")
+        self.assertEqual(hyphenate("a-b"), "a-b")
 
     def test_confirmed_vowel_sequences(self):
         """Test EPA vowel nuclei confirmed during linguistic review"""

--- a/tests/test_syllabifier.py
+++ b/tests/test_syllabifier.py
@@ -76,10 +76,33 @@ class TestSyllabifier(unittest.TestCase):
         self.assertEqual(hyphenate("andalûh"), "an-da-lûh")
         self.assertEqual(hyphenate("ponêl-lo"), "po-nêl-lo")
 
+    def test_hyphenates_text_preserving_separators(self):
+        """Test full text output while preserving punctuation and whitespace"""
+        self.assertEqual(hyphenate("¡Andalûh EPA!"), "¡an-da-lûh e-pa!")
+        self.assertEqual(hyphenate("Hola, mundo.\nEPA"), "ho-la, mun-do.\ne-pa")
+
+    def test_confirmed_vowel_sequences(self):
+        """Test EPA vowel nuclei confirmed during linguistic review"""
+        examples = {
+            "aire": ["ai", "re"],
+            "causa": ["cau", "sa"],
+            "peine": ["pei", "ne"],
+            "ciudá": ["ciu", "dá"],
+            "cuidao": ["cui", "da", "o"],
+            "guau": ["guau"],
+            "día": ["dí", "a"],
+            "tío": ["tí", "o"],
+        }
+        for word, expected_syllables in examples.items():
+            with self.subTest(word=word):
+                self.assertEqual(syllabify(word), expected_syllables)
+
     def test_rejects_non_string_input(self):
         """Test input type validation"""
         with self.assertRaisesRegex(TypeError, "word must be a string"):
             syllabify(None)
+        with self.assertRaisesRegex(TypeError, "text must be a string"):
+            hyphenate(None)
 
     def test_rejects_multiple_units(self):
         """Test that only one word is accepted"""

--- a/tests/test_syllabifier.py
+++ b/tests/test_syllabifier.py
@@ -6,7 +6,7 @@ import unittest
 import csv
 import os
 import epa_syllabifier
-from epa_syllabifier import syllabify
+from epa_syllabifier import hyphenate, syllabify
 
 
 class TestSyllabifier(unittest.TestCase):
@@ -71,26 +71,30 @@ class TestSyllabifier(unittest.TestCase):
         self.assertEqual(syllabify(" TOQUE "), ["to", "que"])
         self.assertEqual(syllabify("ûl-lero"), ["ûl", "le", "ro"])
 
+    def test_hyphenates_word(self):
+        """Test textual output with syllable separators"""
+        self.assertEqual(hyphenate("andalûh"), "an-da-lûh")
+        self.assertEqual(hyphenate("ponêl-lo"), "po-nêl-lo")
+
     def test_rejects_non_string_input(self):
         """Test input type validation"""
         with self.assertRaisesRegex(TypeError, "word must be a string"):
             syllabify(None)
 
-    def test_rejects_invalid_words(self):
-        """Test that only one EPA word is accepted"""
-        invalid_words = [
-            "hola mundo",
-            "123",
-            "hola!",
-            "-andalûh",
-            "andalûh-",
-            "anda--lûh",
-        ]
-
-        for word in invalid_words:
+    def test_rejects_multiple_units(self):
+        """Test that only one word is accepted"""
+        for word in ["hola mundo", "hola\tmundo", "hola\nmundo"]:
             with self.subTest(word=word):
                 with self.assertRaises(ValueError):
                     syllabify(word)
+
+    def test_accepts_words_without_validating_their_spelling(self):
+        """Test that spelling validation is outside the syllabifier scope"""
+        for word in ["darwiniano", "Washington", "hola!", "123"]:
+            with self.subTest(word=word):
+                syllables = syllabify(word)
+                self.assertEqual("".join(syllables), word.lower())
+                self.assertTrue(all(syllables))
 
     def test_gemination_regressions(self):
         """Test that gemination processing never leaves empty fragments"""
@@ -102,7 +106,7 @@ class TestSyllabifier(unittest.TestCase):
 
     def test_public_api(self):
         """Test the package public API"""
-        self.assertEqual(epa_syllabifier.__all__, ["syllabify"])
+        self.assertEqual(epa_syllabifier.__all__, ["hyphenate", "syllabify"])
 
 
 def generate_individual_tests():

--- a/tests/test_syllabifier.py
+++ b/tests/test_syllabifier.py
@@ -60,6 +60,12 @@ class TestSyllabifier(unittest.TestCase):
         self.assertEqual(syllabify("o"), ["o"])
         self.assertEqual(syllabify("u"), ["u"])
 
+    def test_diacritic_vowels(self):
+        """Test EPA grave-accented vowels"""
+        for vowel in ["à", "è", "ì", "ò", "ù"]:
+            with self.subTest(vowel=vowel):
+                self.assertEqual(syllabify(vowel), [vowel])
+
     def test_normalizes_word(self):
         """Test supported word normalization"""
         self.assertEqual(syllabify(" TOQUE "), ["to", "que"])


### PR DESCRIPTION
## Summary

This draft PR resumes the EPA syllabifier work and turns the existing beta implementation into a safer, reproducible local development baseline.

It keeps `syllabify()` as the single-word API, adds `hyphenate()` for complete text, expands EPA vowel handling, introduces an interactive CLI for manual linguistic checks, and adds a reproducible local CI workflow.

## What changed

### Syllabification behavior

- Fix the gemination edge case that could raise `IndexError` while mutating syllable fragments.
- Add explicit input type checks and preserve the single-word contract for `syllabify()`.
- Keep spelling handling intentionally tolerant: the syllabifier attempts to process loans, inherited spellings, and unknown characters without acting as an EPA validator.
- Accept internal orthographic hyphens such as `l-l` during word analysis.
- Add EPA grave-accented vowels: `à`, `è`, `ì`, `ò`, and `ù`.
- Add confirmed vowel nucleus behavior for diphthongs, triphthongs, and hiatuses, including examples such as `ai·re`, `cau·sa`, `ciu·dá`, `guau`, `dí·a`, and `tí·o`.
- Add `hyphenate()` for complete text while preserving punctuation, spaces, line breaks, and EPA orthographic hyphens such as `l-l`. Generated syllable boundaries use the interpunct (`·`) so they remain distinguishable.

### Developer experience

- Fix the public package export from `all` to `__all__`.
- Declare the actual supported Python range as Python `>=3.10` and include Python `3.13` metadata.
- Clean up the Makefile: remove duplicate installs, add the missing build dependency, remove the unusable watch target, and add isolated formatting and linting through `uv`.
- Add `make ci-local` for whitespace checks, formatting checks, coverage, the Python version matrix, and package builds.
- Add `make try` and the installable `epa-syllabifier` command for interactive manual checks:

```text
epa> día
dí·a
```

### Tests and documentation

- Add regression tests for gemination edge cases.
- Add tests for input contracts, tolerant spelling handling, grave vowels, vowel nuclei, text hyphenation, and the interactive CLI.
- Add exhaustive property tests over all EPA-alphabet combinations up to four characters, checking that processing does not raise exceptions, lose characters, or produce empty fragments.
- Document the API, local CI workflow, manual test mode, linguistic sources, and adopted decisions.

## Root cause

The original implementation already contained a useful heuristic, but it mixed list mutation with index-based iteration, had incomplete vowel rules, and did not define input behavior clearly. The development commands also depended on the local environment in ways that made verification inconsistent.

## Validation

Ran successfully:

```bash
make ci-local
```

This covers:

- Black formatting checks
- whitespace checks
- 77 tests with 100% coverage
- exhaustive short-word property tests
- Python 3.10, 3.11, 3.12, and 3.13
- source distribution and wheel builds

## Follow-up work

This PR is intentionally marked as draft because the technical baseline is ready, but linguistic review should continue before treating the package as final:

- Expand the supervised corpus with representative words selected from `andalugeeks/andaluh-py`; expected syllable boundaries still need human review.
- Audit additional linguistic cases: consonant attacks and codas, circumflex and grave-accent combinations, less common geminations, and more `l-l` examples.
- Decide how `hyphenate()` should treat non-lexical tokens such as numbers, dates, and mixed alphanumeric text.
- Resolve the pre-existing license mismatch before a release: `LICENSE` and the README state GPL v3, while `pyproject.toml` declares MIT.
- Review the existing GitHub release and PyPI workflows before publishing a new version, and add remote test CI when this work is ready to move beyond local development.


